### PR TITLE
Preventing pushing the current node's URL to its networkNodes.

### DIFF
--- a/dev/networkNode.js
+++ b/dev/networkNode.js
@@ -127,8 +127,14 @@ app.post('/receive-new-block', function(req, res) {
 // register a node and broadcast it the network
 app.post('/register-and-broadcast-node', function(req, res) {
 	const newNodeUrl = req.body.newNodeUrl;
-	if (bitcoin.networkNodes.indexOf(newNodeUrl) == -1) bitcoin.networkNodes.push(newNodeUrl);
-
+	const nodeNotAlreadyPresent = bitcoin.networkNodes.indexOf(newNodeUrl) == -1;
+  	const notCurrentNode = bitcoin.currentNodeUrl !== newNodeUrl;
+ 	if (nodeNotAlreadyPresent && notCurrentNode){
+	  bitcoin.networkNodes.push(newNodeUrl);
+	}else{
+		res.json({note: 'Node was not added!'});
+	}
+	
 	const regNodesPromises = [];
 	bitcoin.networkNodes.forEach(networkNodeUrl => {
 		const requestOptions = {


### PR DESCRIPTION
When you post a newNodeUrl to the node with the same URL it gets saved with the rest of the network URLS, for example:
if you post http://localhost:3000 to http://localhost:3000/register-and-brodcast-node, you will have the URL in the networkNodes despite its being the same URL for that node.
my change prevents that and it makes sure you can not post a node's URL to its self.